### PR TITLE
examples/demo: fix key events being reread repeatedly

### DIFF
--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -129,8 +129,10 @@ fn check_for_loaded(
 }
 
 // Helper function to see if there was a key press this frame
-pub fn detect_keypress(keys: EventReader<CrosstermKeyEventWrapper>) -> bool {
-    !keys.is_empty()
+pub fn detect_keypress(mut keys: EventReader<CrosstermKeyEventWrapper>) -> bool {
+    let res = !keys.is_empty();
+    keys.clear();
+    res
 }
 
 // Simple update function that most screens will use


### PR DESCRIPTION
Had an issue where CrosstermKeyEventWrapper was not being reset, causing the `demo` example to skip to the last scene with only one or two keypresses. Adding a call to `keys.clear()` as suggested by [the docs](https://docs.rs/bevy/latest/bevy/ecs/event/struct.EventReader.html#method.is_empty) fixes this.